### PR TITLE
Add NutriSnap visit link and update Newcastle Hub URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,7 @@
                         <div class="w-full h-40 sm:h-48 flex items-center justify-center overflow-hidden rounded-md mt-4 border border-gray-200 bg-white">
                            <img src="images/nutrisnap_logo.png" alt="NutriSnap Logo - Green apple with a camera icon" class="max-h-full max-w-full object-contain p-2">
                         </div>
+                        <a href="https://nutrisnap.co.uk" target="_blank" class="cta-link block mt-4">Visit Site &rarr;</a>
                     </article>
                     <article class="portfolio-item bg-gray-50 p-8 rounded-lg border border-gray-200 shadow-sm text-left transition duration-300 ease-in-out hover:shadow-lg active:scale-[.98]">
                         <h4 class="text-xl font-semibold mb-3 text-gray-900">Newcastle Hub Directory</h4>
@@ -128,7 +129,7 @@
                         <div class="w-full h-40 sm:h-48 flex items-center justify-center overflow-hidden rounded-md mt-4 border border-gray-200 bg-gray-800">
                            <img src="images/newcastle_hub_tech_concept.png" alt="Tech-inspired visual for Newcastle Hub Directory" class="max-h-full max-w-full object-contain">
                         </div>
-                         <a href="https://newcastle-hub-directory.com/" target="_blank" class="cta-link block mt-4">Visit Site &rarr;</a>
+                         <a href="https://newcastle-hub-directory.com" target="_blank" class="cta-link block mt-4">Visit Site &rarr;</a>
                     </article>
                 </div>
                  <div class="mt-16">

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -88,6 +88,7 @@
                             <li><strong>Status:</strong> Minimum Viable Product (MVP) developed.</li>
                             <li><strong>Goal:</strong> Empower users to make informed dietary choices effortlessly.</li>
                         </ul>
+                        <a href="https://nutrisnap.co.uk" target="_blank" class="cta-link text-lg">Visit Site <span aria-hidden="true">&rarr;</span></a>
                     </div>
                     <div class="flex justify-center items-center h-56 sm:h-64 bg-white rounded-lg border border-gray-200 p-4 overflow-hidden">
                         <img src="images/nutrisnap_logo.png" alt="NutriSnap Logo - Green apple with a camera icon" class="max-h-full max-w-full object-contain transition duration-300 ease-in-out">
@@ -104,7 +105,7 @@
                             <li><strong>Status:</strong> Live MVP.</li>
                             <li><strong>Goal:</strong> Become a central resource for information within Newcastle.</li>
                         </ul>
-                        <a href="https://newcastle-hub-directory.com/" target="_blank" class="cta-link text-lg">Visit Site <span aria-hidden="true">&rarr;</span></a>
+                        <a href="https://newcastle-hub-directory.com" target="_blank" class="cta-link text-lg">Visit Site <span aria-hidden="true">&rarr;</span></a>
                     </div>
                     <div class="flex justify-center items-center h-56 sm:h-64 bg-gray-800 rounded-lg border border-gray-200 md:order-1 overflow-hidden">
                          <img src="images/newcastle_hub_tech_concept.png" alt="Tech-inspired visual for Newcastle Hub Directory" class="max-h-full max-w-full object-contain transition duration-300 ease-in-out">


### PR DESCRIPTION
## Summary
- add Visit Site link for NutriSnap on the home page
- add Visit Site link for NutriSnap in the portfolio page
- point Newcastle Hub links to `https://newcastle-hub-directory.com`

## Testing
- `npm test --silent`